### PR TITLE
Improve filter robustness

### DIFF
--- a/wsp/command/wintercmd.py
+++ b/wsp/command/wintercmd.py
@@ -4275,7 +4275,7 @@ class Wintercmd(QtCore.QObject):
         
         ## Wait until end condition is satisfied, or timeout ##
         condition = True
-        timeout = 150
+        timeout = 60 * 5
         # create a buffer list to hold several samples over which the stop condition must be true
         n_buffer_samples = self.config.get('cmd_satisfied_N_samples')
         stop_condition_buffer = [(not condition) for i in range(n_buffer_samples)]

--- a/wsp/filterwheel/winterFilterd.py
+++ b/wsp/filterwheel/winterFilterd.py
@@ -408,6 +408,7 @@ class EZStepper(QtCore.QObject):
             self.log(f'We ran into an error: {e}')
 
         # opto check
+        time.sleep(0.5)  # give time for filter tray to settle
         input_status = self.getInputStatus()
         actually_homed = input_status['opto1'] == 0
 


### PR DESCRIPTION
- Turned on logging for the filter
- Added retry functionality to goToLocation
- Set is_homing to 0 if we time out while homing

Nate mentioned an issue where sometimes at telescope startup, the homing command does not complete and needs to be retried. This does **not** automatically check for that and re-home. I think that timeout and retry should go into the startup loop (not sure where that is... searching for fw_home did not reveal it)