### PR TITLE
updating default dithers to min 75 as max 90 as

### DIFF
--- a/wsp/config/config.yaml
+++ b/wsp/config/config.yaml
@@ -961,9 +961,9 @@ observing_parameters:
         #        dRA: 500
         #        dDec: 1000
         dithers: 
-            ditherNumber: 10 #5
-            ditherMinStep_as: 10
-            ditherMaxStep_as: 15
+            ditherNumber: 8 #10 #5
+            ditherMinStep_as: 75 #10
+            ditherMaxStep_as: 90 #15
         best_position:
             board_id: 4
             x_pixel: 800


### PR DESCRIPTION
I thought this was a scheduler issue, but the nightly schedule configs only have number of dithers, not the step size. That means that they are getting the fallback default from the WSP config.yaml file which was still set at min dither radius = 10" max dither radius = 15". I have updated it so that min = 75" and max = 90" to be closer to what we're requesting by default through the WINTER API.

@dfrostig @robertdstein 