### PR TITLE
changed min moon dist to 10 from 25 deg

### DIFF
--- a/wsp/config/config.yaml
+++ b/wsp/config/config.yaml
@@ -586,7 +586,7 @@ weather_limits:
 ephem:
     # note that changing these will not update the housekeeping fields, that must be done manually
     min_target_separation:
-        moon: 25.0
+        moon: 10.0
         mercury: 5
         venus: 5
         mars: 5


### PR DESCRIPTION
Updated the configuration parameters for the min ephemeris distances in config.yaml to allow for pointing as close to 10 deg from the moon (previously has been 25 deg). This came up to chase some TOOs that were in the 15ish deg separation. Will test out and see how it does before merging. @geoffreymo @jpurdum 

Closes #142 

